### PR TITLE
fixes dockerfile by using archived repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,11 @@ FROM debian:stretch
 # Set the working directory to /app
 WORKDIR /application
 
+RUN sed -i -e 's/deb.debian.org/archive.debian.org/g' \
+           -e 's|security.debian.org|archive.debian.org/|g' \
+           -e '/stretch-updates/d' /etc/apt/sources.list
+
+
 RUN apt update
 
 # Add mono package repository and update repositories


### PR DESCRIPTION
Debian moved some of its stretch repos to the archive. Therefore changing the repo adresses manually is required. Otherwise the build will fail. See [this stackoverflow quesiton](https://stackoverflow.com/questions/76094428/debian-stretch-repositories-404-not-found). 

This PR fixes the issues when building the docker container as described in the README.